### PR TITLE
Fix "zeppelin" effect caused by duplicate edges from LossSets

### DIFF
--- a/analyzere_extras/visualizations.py
+++ b/analyzere_extras/visualizations.py
@@ -237,7 +237,7 @@ class LayerViewDigraph(object):
                 ls_id = '{}{}'.format(ls.id,
                                       ' ({})'.format(next(sequence))
                                       if not self._compact else '')
-                if not (ls_name, node_hash) in edges:
+                if not (ls_id, node_hash) in edges:
                     self._graph.attr('node',
                                      shape='box', color='lightgrey',
                                      style='filled', fillcolor='lightgrey')


### PR DESCRIPTION
Fixed "zeppelin" effect on LossSet nodes with duplciate edges:

![image](https://cloud.githubusercontent.com/assets/2412361/22698267/7879a446-ed2a-11e6-908d-b22d6f0a279c.png)


fixed:
![image](https://cloud.githubusercontent.com/assets/2412361/22698319/a0086574-ed2a-11e6-81d3-0d3bfa7ee5a7.png)
