### PR TITLE
Updated default value of render(view) to False to match graphviz

### DIFF
--- a/analyzere_extras/visualizations.py
+++ b/analyzere_extras/visualizations.py
@@ -331,7 +331,7 @@ class LayerViewDigraph(object):
         return LayerViewDigraph(LayerView.retrieve(lv_id), with_terms, compact,
                                 format=format, rankdir=rankdir)
 
-    def render(self, filename=None, view=True, format=None, rankdir=None):
+    def render(self, filename=None, view=False, format=None, rankdir=None):
         """Render a LayerViewDigraph with the Graphviz engine
 
         Optional parameters:
@@ -339,7 +339,8 @@ class LayerViewDigraph(object):
            filename     specify the filename to be used when rendering.
 
            view         exposes the graphviz 'view' option that uses the
-                        default application to open the rendered graph.
+                        default application to open the rendered graph
+                        (default=False).
 
            format       exposes the graphviz 'format' option which include
                         'pdf', 'png', etc.

--- a/tests/test_visualizations.py
+++ b/tests/test_visualizations.py
@@ -584,7 +584,7 @@ class TestLayerViewDigraph:
         lvg._graph = Mock()
 
         lvg.render()
-        lvg._graph.render.assert_called_with(expected_filename, view=True)
+        lvg._graph.render.assert_called_with(expected_filename, view=False)
         assert lvg._filename == expected_filename
 
     def test_render_without_terms(self, layer_view):
@@ -606,7 +606,7 @@ class TestLayerViewDigraph:
         lvg._graph = Mock()
 
         lvg.render()
-        lvg._graph.render.assert_called_with(expected_filename, view=True)
+        lvg._graph.render.assert_called_with(expected_filename, view=False)
         assert lvg._filename == expected_filename
 
     def test_render_compact(self, layer_view):
@@ -628,10 +628,10 @@ class TestLayerViewDigraph:
         lvg._graph = Mock()
 
         lvg.render()
-        lvg._graph.render.assert_called_with(expected_filename, view=True)
+        lvg._graph.render.assert_called_with(expected_filename, view=False)
         assert lvg._filename == expected_filename
 
-    def test_render_without_view(self, layer_view):
+    def test_render_with_view(self, layer_view):
         """Test that the 'compact' parameter affects the filename
         that is is passed to the underlying graphviz.render() method
         """
@@ -647,8 +647,8 @@ class TestLayerViewDigraph:
         # values are passed to its render() method
         lvg._graph = Mock()
 
-        lvg.render(view=False)
-        lvg._graph.render.assert_called_with(expected_filename, view=False)
+        lvg.render(view=True)
+        lvg._graph.render.assert_called_with(expected_filename, view=True)
         assert lvg._filename == expected_filename
 
     def test_render_filename(self, layer_view):
@@ -671,7 +671,7 @@ class TestLayerViewDigraph:
                                                _filename=filename)
 
         lvg.render(filename=filename)
-        lvg._graph.render.assert_called_with(expected_filename, view=True)
+        lvg._graph.render.assert_called_with(expected_filename, view=False)
         assert lvg._filename == expected_filename
 
     def test_render_format(self, layer_view):
@@ -689,7 +689,7 @@ class TestLayerViewDigraph:
 
         lvg.render(format='pdf')
         expected_filename = self._get_filename(layer_view.id)
-        lvg._graph.render.assert_called_with(expected_filename, view=True)
+        lvg._graph.render.assert_called_with(expected_filename, view=False)
         assert lvg._filename == expected_filename
         assert lvg._format == 'pdf'
 
@@ -712,7 +712,7 @@ class TestLayerViewDigraph:
         expected_filename = self._get_filename(layer_view.id,
                                                _rankdir=rankdir)
         lvg.render(rankdir=rankdir)
-        lvg._graph.render.assert_called_with(expected_filename, view=True)
+        lvg._graph.render.assert_called_with(expected_filename, view=False)
         assert lvg._filename == expected_filename
         assert lvg._graph.graph_attr['rankdir'] == 'TB'
 


### PR DESCRIPTION
Update the default value of the `LayerViewDigraph.render(view=)` parameter to `False` to match the default in the underlying [`Digraph.render(view=False)`](http://graphviz.readthedocs.io/en/latest/api.html#graphviz.Digraph.render) method.