### PR TITLE
Switched to explicit file name pattern

### DIFF
--- a/analyzere_extras/visualizations.py
+++ b/analyzere_extras/visualizations.py
@@ -189,9 +189,9 @@ class LayerViewDigraph(object):
                                                   'with-terms'
                                                   if self._with_terms
                                                   else 'without-terms',
-                                                  'with-warnings'
+                                                  'warnings-enabled'
                                                   if self._warnings
-                                                  else 'without-warnings'))
+                                                  else 'warnings-disabled'))
 
     def _generate_nodes(self, l, sequence, unique_nodes, edges,
                         parent_hash=None, prefix=None):

--- a/analyzere_extras/visualizations.py
+++ b/analyzere_extras/visualizations.py
@@ -178,14 +178,20 @@ class LayerViewDigraph(object):
     """
     def _update_filename(self, filename=None):
         # build filename with format:
-        #    '<lv_id>_<rankdir><_not_compact><_with_terms>.<format>'
+        #    '<lv_id>_<rankdir>_<[not-]compact>_<with[out]-terms>\
+        #    _<with[out]-warnings>.<format>'
         self._filename = (filename if filename else
-                          '{}_{}{}{}'.format(self._lv.id,
-                                             self._rankdir,
-                                             '' if self._compact
-                                             else '_not_compact',
-                                             '_with_terms' if self._with_terms
-                                             else ''))
+                          '{}_{}_{}_{}_{}'.format(self._lv.id,
+                                                  self._rankdir,
+                                                  'compact'
+                                                  if self._compact
+                                                  else 'not-compact',
+                                                  'with-terms'
+                                                  if self._with_terms
+                                                  else 'without-terms',
+                                                  'with-warnings'
+                                                  if self._warnings
+                                                  else 'without-warnings'))
 
     def _generate_nodes(self, l, sequence, unique_nodes, edges,
                         parent_hash=None, prefix=None):

--- a/tests/test_visualizations.py
+++ b/tests/test_visualizations.py
@@ -486,12 +486,16 @@ class TestLayerViewDigraph:
         args = default_LayerViewDigraph_args()
         args.update(overrides)
         filename = (args['_filename'] if '_filename' in args else
-                    '{}_{}{}{}'.format(lv_id,
-                                       args['_rankdir'],
-                                       '' if args['_compact']
-                                       else '_not_compace',
-                                       '_with_terms' if args['_with_terms']
-                                       else ''))
+                    '{}_{}_{}_{}_{}'.format(lv_id,
+                                            args['_rankdir'],
+                                            'compact' if args['_compact']
+                                            else 'not-compact',
+                                            'with-terms'
+                                            if args['_with_terms']
+                                            else 'without-terms',
+                                            'with-warnings'
+                                            if args['_warnings']
+                                            else 'without-warnings'))
         return filename
 
     def _validate_args(self, lvg, **overrides):

--- a/tests/test_visualizations.py
+++ b/tests/test_visualizations.py
@@ -493,9 +493,9 @@ class TestLayerViewDigraph:
                                             'with-terms'
                                             if args['_with_terms']
                                             else 'without-terms',
-                                            'with-warnings'
+                                            'warnings-enabled'
                                             if args['_warnings']
-                                            else 'without-warnings'))
+                                            else 'warnings-disabled'))
         return filename
 
     def _validate_args(self, lvg, **overrides):


### PR DESCRIPTION
Prefer filenames that explicitly include the values of the optional parameters:

```
$ ls -1 
aa52e4ad-c5ad-4653-a321-0cdf3643316d_BT_compact_without-terms_without-warnings.png
aa52e4ad-c5ad-4653-a321-0cdf3643316d_BT_compact_without-terms_with-warnings.png
aa52e4ad-c5ad-4653-a321-0cdf3643316d_BT_compact_with-terms_without-warnings.png
aa52e4ad-c5ad-4653-a321-0cdf3643316d_BT_compact_with-terms_with-warnings.png
aa52e4ad-c5ad-4653-a321-0cdf3643316d_BT_not-compact_without-terms_without-warnings.png
aa52e4ad-c5ad-4653-a321-0cdf3643316d_BT_not-compact_with-terms_with-warnings.png
aa52e4ad-c5ad-4653-a321-0cdf3643316d_LR_compact_without-terms_without-warnings.png
aa52e4ad-c5ad-4653-a321-0cdf3643316d_LR_compact_without-terms_with-warnings.png
aa52e4ad-c5ad-4653-a321-0cdf3643316d_LR_compact_with-terms_without-warnings.png
aa52e4ad-c5ad-4653-a321-0cdf3643316d_LR_compact_with-terms_with-warnings.png
aa52e4ad-c5ad-4653-a321-0cdf3643316d_LR_not-compact_without-terms_without-warnings.png
aa52e4ad-c5ad-4653-a321-0cdf3643316d_LR_not-compact_with-terms_with-warnings.png
aa52e4ad-c5ad-4653-a321-0cdf3643316d_TB_compact_without-terms_without-warnings.png
aa52e4ad-c5ad-4653-a321-0cdf3643316d_TB_compact_without-terms_with-warnings.png
aa52e4ad-c5ad-4653-a321-0cdf3643316d_TB_compact_with-terms_without-warnings.png
aa52e4ad-c5ad-4653-a321-0cdf3643316d_TB_compact_with-terms_with-warnings.png
aa52e4ad-c5ad-4653-a321-0cdf3643316d_TB_not-compact_without-terms_without-warnings.png
aa52e4ad-c5ad-4653-a321-0cdf3643316d_TB_not-compact_with-terms_with-warnings.png
$ 
```