### PR TITLE
 ARE-7945 : Allow for Empty (NULL) Inception and Expiry Dates

### DIFF
--- a/analyzere_extras/visualizations.py
+++ b/analyzere_extras/visualizations.py
@@ -116,7 +116,8 @@ def _format_layer_terms(layer):
     formatter = FormattingHelper(layer)
 
     if hasattr(layer, 'inception_date') or hasattr(layer, 'expiry_date'):
-        formatter.append_term('coverage', _format_coverage(layer))
+        if layer.inception_date is not None and layer.expiry_date is not None: 
+            formatter.append_term('coverage', _format_coverage(layer))
 
     formatter.append('participation', display_name='share',
                      formatter=lambda x: '{}%'.format(x*100),


### PR DESCRIPTION
Common occurrence of error in testing to integrate viz tool in new notebook repo. 

When layers contain no inception and expiry dates tool crashes. This occurs when _format_coverage function calls the none type from the layer.

![image](https://user-images.githubusercontent.com/12804992/208718496-eee52c1d-f79d-434c-96ff-f79cd13520db.png)
